### PR TITLE
GSdx: Disable Nvidia Hack on AMD/Intel

### DIFF
--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -41,10 +41,8 @@ GSDevice11::GSDevice11()
 
 	if (theApp.GetConfigB("UserHacks")) {
 		UserHacks_unscale_pt_ln = theApp.GetConfigB("UserHacks_unscale_point_line");
-		UserHacks_disable_NV_hack = theApp.GetConfigB("UserHacks_DisableNVhack");
 	} else {
 		UserHacks_unscale_pt_ln = false;
-		UserHacks_disable_NV_hack = false;
 	}
 }
 
@@ -1298,8 +1296,8 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector
 		D3D11_VIEWPORT vp;
 		memset(&vp, 0, sizeof(vp));
 
-		vp.TopLeftX = (UserHacks_disable_NV_hack || spritehack > 0 || isNative) ? 0.0f : -0.01f;
-		vp.TopLeftY = (UserHacks_disable_NV_hack || spritehack > 0 || isNative) ? 0.0f : -0.01f;
+		vp.TopLeftX = (!GSUtil::IsNvidiaHack() || spritehack > 0 || isNative) ? 0.0f : -0.01f;
+		vp.TopLeftY = (!GSUtil::IsNvidiaHack() || spritehack > 0 || isNative) ? 0.0f : -0.01f;
 		vp.Width = (float)size.x;
 		vp.Height = (float)size.y;
 		vp.MinDepth = 0.0f;

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -209,6 +209,25 @@ bool GSUtil::HasCompatibleBits(uint32 spsm, uint32 dpsm)
 	return (s_maps.CompatibleBitsField[spsm][dpsm >> 5] & (1 << (dpsm & 0x1f))) != 0;
 }
 
+bool GSUtil::IsNvidiaHack()
+{
+	CComPtr<IDXGIFactory1> dxgi_factory;
+	if (SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&dxgi_factory))))
+	{
+		CComPtr<IDXGIAdapter1> adapter;
+		if (SUCCEEDED(dxgi_factory->EnumAdapters1(0, &adapter)))
+		{
+			DXGI_ADAPTER_DESC1 desc;
+			if (SUCCEEDED(adapter->GetDesc1(&desc)))
+			{
+				// Check for Nvidia VendorID. Nvidia needs a special hack.
+				if (desc.VendorId == _NVIDIA_VENDOR_ID)
+					return true;
+			}
+		}
+	}
+}
+
 bool GSUtil::CheckSSE()
 {
 	bool status = true;
@@ -424,7 +443,7 @@ GSRendererType GSUtil::GetBestRenderer()
 			{
 				D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
 				// Check for Nvidia VendorID. Latest OpenGL features need at least DX11 level GPU
-				if (desc.VendorId == 0x10DE && level >= D3D_FEATURE_LEVEL_11_0)
+				if (desc.VendorId == _NVIDIA_VENDOR_ID && level >= D3D_FEATURE_LEVEL_11_0)
 					return GSRendererType::OGL_HW;
 				if (level >= D3D_FEATURE_LEVEL_10_0)
 					return GSRendererType::DX1011_HW;

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -24,6 +24,10 @@
 #include "GS.h"
 #include "xbyak/xbyak_util.h"
 
+#define _NVIDIA_VENDOR_ID	0x10DE
+#define _AMD_VENDOR_ID		0x1002 || 0x1022
+#define _INTEL_VENDOR_ID	0x8086 || 0x8087 || 0x163C
+
 struct OCLDeviceDesc
 {
 #ifdef ENABLE_OPENCL

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -434,7 +434,6 @@ void GSdxApp::Init()
 	m_default_configuration["UserHacks_DisableDepthSupport"]              = "0";
 	m_default_configuration["UserHacks_CPU_FB_Conversion"]                = "0";
 	m_default_configuration["UserHacks_DisableGsMemClear"]                = "0";
-	m_default_configuration["UserHacks_DisableNVhack"]                    = "0";
 	m_default_configuration["UserHacks_DisablePartialInvalidation"]       = "0";
 	m_default_configuration["UserHacks_HalfPixelOffset"]                  = "0";
 	m_default_configuration["UserHacks_merge_pp_sprite"]                  = "0";


### PR DESCRIPTION
Always disable nvidia hack on AMD/Intel, it's not needed.